### PR TITLE
feat: support JsonValue annotations on enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` for considering `@JsonValue` annotations on enums, similar to `Option.FLATTENED_ENUMS`
 
 ## [4.4.0] - 2020-03-04
 - No feature changes, just bumping of minor version to indicate compatibility with `jsonschema-generator` version `4.4.*`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Module for the `jsonschema-generator` – deriving JSON Schema attributes from `
 2. Populate a type's "description" as per `@JsonClassDescription`.
 3. Apply alternative field names defined in `@JsonProperty` annotations.
 4. Ignore fields that are deemed to be ignored according to various `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
+5. Optionally: treat enum types as plain strings, serialized by `@JsonValue` annotated method
 
 Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.
 

--- a/src/main/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProvider.java
+++ b/src/main/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.members.ResolvedMethod;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.SchemaConstants;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.impl.AttributeCollector;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of the {@link CustomDefinitionProviderV2} interface for treating enum types as plain strings based on a {@link JsonValue @JsonValue}
+ * annotation being present with {@code value = true} on exactly one argument-free method. If no such annotation exists, no custom definition will be
+ * returned; thereby falling back on whatever is defined in a following custom definition (e.g. from one of the standard {@code Option}s).
+ */
+public class CustomEnumJsonValueDefinitionProvider implements CustomDefinitionProviderV2 {
+
+    @Override
+    public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+        Object[] enumConstants = javaType.getErasedType().getEnumConstants();
+        if (enumConstants == null || enumConstants.length == 0) {
+            return null;
+        }
+        ResolvedMethod jsonValueAnnotatedEnumMethod = this.getJsonValueAnnotatedMethod(javaType, context);
+        if (jsonValueAnnotatedEnumMethod == null) {
+            return null;
+        }
+        List<Object> serialisedJsonValues = new ArrayList<>(enumConstants.length);
+        try {
+            for (Object enumConstant : enumConstants) {
+                serialisedJsonValues.add(jsonValueAnnotatedEnumMethod.getRawMember().invoke(enumConstant));
+            }
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            return null;
+        }
+        ObjectNode customNode = context.getGeneratorConfig().createObjectNode()
+                .put(SchemaConstants.TAG_TYPE, SchemaConstants.TAG_TYPE_STRING);
+        AttributeCollector standardAttributeCollector = new AttributeCollector(context.getGeneratorConfig().getObjectMapper());
+        standardAttributeCollector.setEnum(customNode, serialisedJsonValues);
+        return new CustomDefinition(customNode);
+    }
+
+    /**
+     * Look-up the single {@link JsonValue} annotated method with {@code value = true} and no expected arguments.
+     *
+     * @param javaType targeted type to look-up serialization method for
+     * @param context generation context providing access to type resolution context
+     * @return single method with {@link JsonValue} annotation
+     */
+    protected ResolvedMethod getJsonValueAnnotatedMethod(ResolvedType javaType, SchemaGenerationContext context) {
+        ResolvedMethod[] memberMethods = context.getTypeContext().resolveWithMembers(javaType).getMemberMethods();
+        Set<ResolvedMethod> jsonValueAnnotatedMethods = Stream.of(memberMethods)
+                .filter(method -> method.getArgumentCount() == 0)
+                .filter(method -> Optional.ofNullable(method.getAnnotations().get(JsonValue.class)).map(JsonValue::value).orElse(false))
+                .collect(Collectors.toSet());
+        if (jsonValueAnnotatedMethods.size() == 1) {
+            return jsonValueAnnotatedMethods.iterator().next();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProvider.java
+++ b/src/main/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProvider.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Implementation of the {@link CustomDefinitionProviderV2} interface for treating enum types as plain strings based on a {@link JsonValue @JsonValue}
- * annotation being present with {@code value = true} on exactly one argument-free method. If no such annotation exists, no custom definition will be
- * returned; thereby falling back on whatever is defined in a following custom definition (e.g. from one of the standard {@code Option}s).
+ * Implementation of the {@link CustomDefinitionProviderV2} interface for treating enum types as plain strings based on a {@link JsonValue} annotation
+ * being present with {@code value = true} on exactly one argument-free method. If no such annotation exists, no custom definition will be returned;
+ * thereby falling back on whatever is defined in a following custom definition (e.g. from one of the standard generator {@code Option}s).
  */
 public class CustomEnumJsonValueDefinitionProvider implements CustomDefinitionProviderV2 {
 

--- a/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+/**
+ * Flags to enable/disable certain aspects of the {@link JacksonModule}'s processing.
+ */
+public enum JacksonOption {
+    /**
+     * Use this option to treat enum types with a {@link com.fasterxml.jackson.annotation.JsonValue JsonValue} annotation on one of its methods as
+     * plain strings in the generated schema. If no such annotation with {@code value = true} is present on exactly one argument-free method, it will
+     * fall-back on following custom definitions (e.g. from one of the standard generator options.
+     *
+     * @see com.github.victools.jsonschema.generator.Option#FLATTENED_ENUMS
+     * @see com.github.victools.jsonschema.generator.Option#FLATTENED_ENUMS_FROM_TOSTRING
+     */
+    FLATTENED_ENUMS_FROM_JSONVALUE;
+}

--- a/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -23,7 +23,7 @@ public enum JacksonOption {
     /**
      * Use this option to treat enum types with a {@link com.fasterxml.jackson.annotation.JsonValue JsonValue} annotation on one of its methods as
      * plain strings in the generated schema. If no such annotation with {@code value = true} is present on exactly one argument-free method, it will
-     * fall-back on following custom definitions (e.g. from one of the standard generator options.
+     * fall-back on following custom definitions (e.g. from one of the standard generator {@code Option}s).
      *
      * @see com.github.victools.jsonschema.generator.Option#FLATTENED_ENUMS
      * @see com.github.victools.jsonschema.generator.Option#FLATTENED_ENUMS_FROM_TOSTRING

--- a/src/test/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProviderTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/jackson/CustomEnumJsonValueDefinitionProviderTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.members.ResolvedMethod;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.SchemaConstants;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.TypeContext;
+import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+/**
+ * Test for the {@link CustomEnumJsonValueDefinitionProvider}.
+ */
+@RunWith(JUnitParamsRunner.class)
+public class CustomEnumJsonValueDefinitionProviderTest {
+
+    private final CustomEnumJsonValueDefinitionProvider definitionProvider = new CustomEnumJsonValueDefinitionProvider();
+    private final TypeContext typeContext = TypeContextFactory.createDefaultTypeContext();
+    private SchemaGenerationContext generationContext;
+
+    @Before
+    public void setUp() {
+        this.generationContext = Mockito.mock(SchemaGenerationContext.class, Answers.RETURNS_DEEP_STUBS);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Mockito.when(this.generationContext.getTypeContext()).thenReturn(this.typeContext);
+        Mockito.when(this.generationContext.getGeneratorConfig().getObjectMapper()).thenReturn(objectMapper);
+        Mockito.when(this.generationContext.getGeneratorConfig().createObjectNode())
+                .thenAnswer((_invocation) -> objectMapper.createObjectNode());
+    }
+
+    @Test
+    public void testProvideCustomSchemaDefinition() {
+        ResolvedType type = this.typeContext.resolve(EnumWithJsonValue.class);
+        CustomDefinition result = this.definitionProvider.provideCustomSchemaDefinition(type, this.generationContext);
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isMeantToBeInline());
+        ObjectNode customDefinitionNode = result.getValue();
+        Assert.assertEquals(2, customDefinitionNode.size());
+        Assert.assertEquals(SchemaConstants.TAG_TYPE_STRING, customDefinitionNode.get(SchemaConstants.TAG_TYPE).asText());
+        JsonNode enumNode = customDefinitionNode.get(SchemaConstants.TAG_ENUM);
+        Assert.assertTrue(enumNode.isArray());
+        ArrayNode arrayNode = (ArrayNode) enumNode;
+        Assert.assertEquals(2, arrayNode.size());
+        Assert.assertEquals("json-value-ENTRY1", arrayNode.get(0).asText());
+        Assert.assertEquals("json-value-ENTRY2", arrayNode.get(1).asText());
+    }
+
+    public Object[] parametersForTestProvideForInvalidTargetType() {
+        return new Object[][]{
+            {Enum.class},
+            {ClassWithJsonValue.class},
+            {EmptyEnumWithJsonValue.class},
+            {EnumWithInvalidJsonValue.class},
+            {EnumWithInactiveJsonValue.class},
+            {EnumWithTwoJsonValues.class}};
+    }
+
+    @Test
+    @Parameters
+    public void testProvideForInvalidTargetType(Class<?> erasedType) {
+        CustomDefinition result = this.definitionProvider.provideCustomSchemaDefinition(this.typeContext.resolve(erasedType), this.generationContext);
+        Assert.assertNull(result);
+    }
+
+    public Object[] parametersForTestGetJsonValueAnnotatedMethod() {
+        return new Object[][]{
+            {Enum.class, null},
+            {ClassWithJsonValue.class, "serialise"},
+            {EmptyEnumWithJsonValue.class, "asText"},
+            {EnumWithInvalidJsonValue.class, null},
+            {EnumWithInactiveJsonValue.class, null},
+            {EnumWithTwoJsonValues.class, null},
+            {EnumWithJsonValue.class, "getJsonValue"}};
+    }
+
+    @Test
+    @Parameters
+    public void testGetJsonValueAnnotatedMethod(Class<?> erasedType, String methodName) {
+        ResolvedMethod result = this.definitionProvider.getJsonValueAnnotatedMethod(this.typeContext.resolve(erasedType), this.generationContext);
+        if (methodName == null) {
+            Assert.assertNull(result);
+        } else {
+            Assert.assertEquals(methodName, result.getRawMember().getName());
+        }
+    }
+
+    private static final class ClassWithJsonValue {
+
+        @JsonValue
+        public String serialise() {
+            return "ClassWithJsonValue";
+        }
+    }
+
+    private static enum EmptyEnumWithJsonValue {
+        ;
+
+        @JsonValue
+        public String asText() {
+            return "ClassWithJsonValue";
+        }
+    }
+
+    private static enum EnumWithInvalidJsonValue {
+        ENTRY;
+
+        @JsonValue
+        public String serialize(String context) {
+            return context + ":" + this.name();
+        }
+    }
+
+    private static enum EnumWithInactiveJsonValue {
+        ENTRY;
+
+        @JsonValue(false)
+        public String serialize() {
+            return this.name();
+        }
+    }
+
+    private static enum EnumWithTwoJsonValues {
+        ENTRY;
+
+        @JsonValue
+        public String getValue1() {
+            return "X";
+        }
+
+        @JsonValue
+        public String getValue2() {
+            return "Y";
+        }
+    }
+
+    private static enum EnumWithJsonValue {
+        ENTRY1, ENTRY2;
+
+        @JsonValue
+        public String getJsonValue() {
+            return "json-value-" + this.name();
+        }
+    }
+}

--- a/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -19,8 +19,10 @@ package com.github.victools.jsonschema.module.jackson;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -44,8 +46,8 @@ public class IntegrationTest {
      */
     @Test
     public void testIntegration() throws Exception {
-        JacksonModule module = new JacksonModule();
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper())
+        JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), OptionPreset.PLAIN_JSON)
                 .with(module)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
@@ -78,5 +80,22 @@ public class IntegrationTest {
 
         @JsonProperty("fieldWithOverriddenName")
         public boolean originalFieldName;
+
+        public TestEnum enumValueHandledByStandardOption;
+
+        public TestEnumWithJsonValueAnnotation enumValueWithJsonValueAnnotation;
+    }
+
+    static enum TestEnum {
+        A, B, C;
+    }
+
+    static enum TestEnumWithJsonValueAnnotation {
+        ENTRY1, ENTRY2, ENTRY3;
+
+        @JsonValue
+        public String getJsonValue() {
+            return this.name().toLowerCase();
+        }
     }
 }

--- a/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -57,6 +57,24 @@ public class JacksonModuleTest {
     public void testApplyToConfigBuilder() {
         new JacksonModule().applyToConfigBuilder(this.configBuilder);
 
+        this.verifyCommonConfigurations();
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.typesInGeneralConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithFlattenedEnumOption() {
+        new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verify(this.typesInGeneralConfigPart).withCustomDefinitionProvider(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.typesInGeneralConfigPart);
+    }
+
+    private void verifyCommonConfigurations() {
         Mockito.verify(this.configBuilder).getObjectMapper();
         Mockito.verify(this.configBuilder).forFields();
         Mockito.verify(this.configBuilder).forTypesInGeneral();
@@ -66,8 +84,6 @@ public class JacksonModuleTest {
         Mockito.verify(this.fieldConfigPart).withPropertyNameOverrideResolver(Mockito.any());
 
         Mockito.verify(this.typesInGeneralConfigPart).withDescriptionResolver(Mockito.any());
-
-        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart);
     }
 
     Object parametersForTestPropertyNameOverride() {

--- a/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -1,8 +1,17 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "enumValueHandledByStandardOption": {
+            "type": "string",
+            "enum": ["A", "B", "C"]
+        },
+        "enumValueWithJsonValueAnnotation": {
+            "type": "string",
+            "enum": ["entry1", "entry2", "entry3"]
+        },
         "fieldWithDescription": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": "field description"
         },
         "fieldWithOverriddenName": {


### PR DESCRIPTION
This implements feature request https://github.com/victools/jsonschema-generator/issues/27

Introducing a new `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` that can be provided in the `JacksonModule`'s constructor.
When included, any enum with a single eligible `@JsonValue` annotated method will be treated as a string as per standard `Option.FLATTENED_ENUMS`, but invoking the annotated method instead of `name()` (or `toString()` in case of `Option.FLATTENED_ENUMS_FROM_TOSTRING`).

When encountering an enum without such an annotated method, the default handling applies – i.e. it is recommended to combine this new `JacksonOption` with your desired default behavior (either falling-back on `name()` or `toString()`) steered via one of the aforementioned standard `Option` values on the main `jsonschema-generator`.